### PR TITLE
Fix inverted coordinates

### DIFF
--- a/notebooks/web_feature_services.ipynb
+++ b/notebooks/web_feature_services.ipynb
@@ -98,6 +98,7 @@
     "import cartopy.crs as ccrs\n",
     "import panel as pn\n",
     "import requests\n",
+    "import shapely\n",
     "import geopandas as gpd\n",
     "from owslib.wfs import WebFeatureService\n",
     "\n",
@@ -136,6 +137,7 @@
     "base_resource_url = \"https://mapservices.weather.noaa.gov/vector/services/outlooks/cpc_6_10_day_outlk/MapServer/WFSServer?service=WFS&version=1.0.0&request=GetFeature&srsname=EPSG%3A4326&typename=cpc_6_10_day_outlk%3ACPC_6-10_Day_Temperature_Outlook&propertyname=%2A\"\n",
     "feature = get_wfs_feature(base_resource_url)\n",
     "gdf = gpd.read_file(feature)\n",
+    "gdf[\"geometry\"] = gdf[\"geometry\"].map(lambda polygon: shapely.ops.transform(lambda x, y: (y, x), polygon))  # flip x and y\n",
     "gdf.head()"
    ]
   },
@@ -245,7 +247,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.12.4"
   },
   "nbdime-conflicts": {
    "local_diff": [


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->

The coordinates were inverted due to changes from the provider I think.

Now it's fixed:
<img width="1630" alt="image" src="https://github.com/user-attachments/assets/928c1474-e723-41b9-bb3c-3df084ff36fa">

